### PR TITLE
[MOD]更新.gitignre,同时修改GsonTest的代码，使得支持Gson的反序列化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+# IDEA
+.idea/
+target/
+*.iml

--- a/src/main/java/cn/yjxxclub/ObjectToJsonPressureTest/App.java
+++ b/src/main/java/cn/yjxxclub/ObjectToJsonPressureTest/App.java
@@ -1,5 +1,10 @@
 package cn.yjxxclub.ObjectToJsonPressureTest;
 
+import cn.yjxxclub.ObjectToJsonPressureTest.test.FastJsonTest;
+import cn.yjxxclub.ObjectToJsonPressureTest.test.GsonTest;
+import cn.yjxxclub.ObjectToJsonPressureTest.test.JacksonTest;
+import cn.yjxxclub.ObjectToJsonPressureTest.test.JsonlibTest;
+
 /**
  * Hello world!
  *
@@ -7,6 +12,13 @@ package cn.yjxxclub.ObjectToJsonPressureTest;
 public class App {
     public static void main( String[] args ) {
         System.out.println( "Hello World!" );
-
+        FastJsonTest.main(args);
+        System.out.println("================");
+        JacksonTest.main(args);
+        System.out.println("================");
+        GsonTest.main(args);
+//        System.out.println("================");
+//        JsonlibTest.main(args);
+        System.out.println("End");
     }
 }

--- a/src/main/java/cn/yjxxclub/ObjectToJsonPressureTest/test/GsonTest.java
+++ b/src/main/java/cn/yjxxclub/ObjectToJsonPressureTest/test/GsonTest.java
@@ -3,9 +3,9 @@ package cn.yjxxclub.ObjectToJsonPressureTest.test;
 import cn.yjxxclub.ObjectToJsonPressureTest.Common;
 import cn.yjxxclub.ObjectToJsonPressureTest.entity.Book;
 import cn.yjxxclub.ObjectToJsonPressureTest.util.DateUtil;
-import com.google.gson.Gson;
-import com.google.gson.JsonSyntaxException;
+import com.google.gson.*;
 
+import java.lang.reflect.Type;
 import java.util.Date;
 
 /**
@@ -27,10 +27,19 @@ public class GsonTest {
         String str = "{\"createDate\":1498616533082,\"id\":1,\"name\":\"aa\",\"price\":22.1,\"publish\":false}";
 
         long times = Common.TEST_TIMES;
-        Gson gson = new Gson();
+
+        GsonBuilder builder = new GsonBuilder();
+
+        builder.registerTypeAdapter(Date.class, new com.google.gson.JsonDeserializer() {
+            public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException{
+                return new Date(json.getAsJsonPrimitive().getAsLong());
+            }
+        });
+        Gson gson = builder.create();
         for (int i =0;i<12;i++){
             Date date = new Date();
-            serialize(gson,book,times);
+            //serialize(gson,book,times);
+            deserialize(gson,str,times);
             logTime(DateUtil.totalTime(date));
         }
        // deserialize(gson,str,times);

--- a/src/main/java/cn/yjxxclub/ObjectToJsonPressureTest/test/JacksonTest.java
+++ b/src/main/java/cn/yjxxclub/ObjectToJsonPressureTest/test/JacksonTest.java
@@ -29,7 +29,8 @@ public class JacksonTest {
         ObjectMapper objectMapper =new ObjectMapper();
         for (int i =0;i<12;i++){
             Date date = new Date();
-            serialize(objectMapper,book,times);
+            //serialize(objectMapper,book,times);
+            deserialize(objectMapper,str,times);
             logTime(DateUtil.totalTime(date));
         }
     //    deserialize(objectMapper,str,times);

--- a/src/main/java/cn/yjxxclub/ObjectToJsonPressureTest/util/DateUtil.java
+++ b/src/main/java/cn/yjxxclub/ObjectToJsonPressureTest/util/DateUtil.java
@@ -25,8 +25,8 @@ public class DateUtil {
         return format.format(date);
     }
 
-    public static String totalTime(Date old){
+    public static long totalTime(Date old){
         Date now = new Date();
-        return getformat(new Date(now.getTime()-old.getTime()));
+        return now.getTime()-old.getTime();
     }
 }

--- a/src/main/java/cn/yjxxclub/ObjectToJsonPressureTest/util/DateUtil.java
+++ b/src/main/java/cn/yjxxclub/ObjectToJsonPressureTest/util/DateUtil.java
@@ -27,6 +27,7 @@ public class DateUtil {
 
     public static long totalTime(Date old){
         Date now = new Date();
+        //return getformat(new Date(now.getTime()-old.getTime()));
         return now.getTime()-old.getTime();
     }
 }


### PR DESCRIPTION
Hi, tengxin，最近需要统计一下四种JSON解析工具的性能对比，在Git上看到了代码，发现Gson在旧有代码的基础上无法反序列化日期，修改代码，可以进行反序列化日期。
同时也修改了耗时用毫秒表示，而不是打印日期。